### PR TITLE
set limit of 1024KiB to boot nodes as well as for store nodes

### DIFF
--- a/ansible/group_vars/boot.yml
+++ b/ansible/group_vars/boot.yml
@@ -37,6 +37,7 @@ nim_waku_rpc_tcp_port: 8545
 nim_waku_websock_port: 443
 
 # Limits
+nim_waku_max_msg_size: '1024KiB'
 nim_waku_p2p_max_connections: 300
 nim_waku_ip_colocation_limit: 100
 


### PR DESCRIPTION
This PR is aiming to overcome an issue reported by @chaitanyaprem 

> I was testing lightpush and was facing this error randomly 

> ERROR[05-30|11:36:14.556|github.com/status-im/status-go/wakuv2/waku.go:971]                                          could not send message                   envelopeHash=0x7f975bba4ce423ec16d9d08246b30ff6f215e0d0facb533f30d6aa68a4346222 pubsubTopic=/waku/2/rs/16/32 contentTopic=/waku/1/0x3bcb8b29/rfc26 timestamp=1,717,049,163,482,902,000 error="Message size exceeded maximum of 153600 bytes"


> When i looked into it, i had noticed that some of the fleet nodes are returning this error. Had observed the same in shards.staging fleet node logs as well. 
> Taking a look at repo for vars in infra, i had noticed the following config only specified in store nodes and not in boot nodes.
Unless i am missing something, this doesn't seem right and needs to be fixed. For all shards.staging and shards.test  nodes that run relay and lightpush we need to set maxMsgSize to 1MB. 
Otherwise messages would not get propagated properly in the network and randomly things would get dropped. 

> nim_waku_max_msg_size: '1024KiB'

> https://github.com/status-im/infra-shards/blob/9bbed44078d59537167495b21a018de191187395/ansible/group_vars/store.yml#L38


![image](https://github.com/status-im/infra-shards/assets/128452529/7e4024fc-cb38-40b7-a8ce-94da8c6cd8b0)
