### PR TITLE
set max_locks_per_transaction to 2160

### DIFF
--- a/ansible/group_vars/store-db.yml
+++ b/ansible/group_vars/store-db.yml
@@ -27,6 +27,7 @@ postgres_alter_system_settings:
   checkpoint_timeout: '5min'
   max_wal_size: '1GB'
   min_wal_size: '80MB'
+  max_locks_per_transaction: '2160'
 
 # Open PostgreSQL Port
 open_ports_default_comment: '{{ postgres_ha_service_name }}'


### PR DESCRIPTION
### Description
We are using partitions in our postgres DBs. And we have one partition per hour (24 partitions per day.)

The default max_locks_per_transaction value (64) can cause "our of memory" and block issues in the DB because we use to have more than 64 partitions.

With 2160 we aim to avoid that issue for 90 days (2160 == 90*24.) if we consider a time retention policy of 90 days. Nevertheless, we usually have time retention policy of 30 days in our Status fleets, but we are just adding some extra margin.

### Issue
PostgreSQL doesn't respond properly during E2E tests - closes https://github.com/waku-org/nwaku/issues/2838