### PR TITLE
store-db add more appropriate db settings for current db hw

### DIFF
--- a/ansible/group_vars/store-db.yml
+++ b/ansible/group_vars/store-db.yml
@@ -32,6 +32,25 @@ postgres_ha_alter_system_settings:
   max_locks_per_transaction: '2160'
   autovacuum_work_mem: '{{ ((ansible_memtotal_mb * 0.1) * 1000) | int }}' # kB
 
+  ## The following are obtained from https://pgtune.leopard.in.ua/ (8GB RAM 4CPUs SSD PG version 15)
+  max_connections: '300'
+  shared_buffers: '2GB'
+  effective_cache_size: '6GB'
+  maintenance_work_mem: '512MB'
+  checkpoint_completion_target: '0.9'
+  wal_buffers: '16MB'
+  default_statistics_target: '100'
+  random_page_cost: '1.1'
+  effective_io_concurrency: '200'
+  work_mem: '3495kB'
+  huge_pages: 'off'
+  min_wal_size: '2GB'
+  max_wal_size: '8GB'
+  max_worker_processes: '4'
+  max_parallel_workers_per_gather: '2'
+  max_parallel_workers: '4'
+  max_parallel_maintenance_workers: '2'
+
 # Open PostgreSQL Port
 open_ports_default_comment: '{{ postgres_ha_service_name }}'
 open_ports_default_chain: 'SERVICES'

--- a/ansible/group_vars/store-db.yml
+++ b/ansible/group_vars/store-db.yml
@@ -25,31 +25,36 @@ postgres_ha_databases:
     pass: '{{lookup("bitwarden", "fleets/status/"+stage+"/db/nim-waku")}}'
 
 # Avoid exceeding volume size with WAL log.
-postgres_ha_alter_system_settings:
+postgres_ha_alter_system_settings: '{{ postgres_system_setting_default | combine(postgres_system_setting_stage[stage])}}'
+
+postgres_system_setting_default:
   checkpoint_timeout: '5min'
   max_wal_size: '1GB'
   min_wal_size: '80MB'
   max_locks_per_transaction: '2160'
   autovacuum_work_mem: '{{ ((ansible_memtotal_mb * 0.1) * 1000) | int }}' # kB
 
+postgres_system_setting_stage:
+  staging: {}
+  prod:
   ## The following are obtained from https://pgtune.leopard.in.ua/ (8GB RAM 4CPUs SSD PG version 15)
-  max_connections: '300'
-  shared_buffers: '2GB'
-  effective_cache_size: '6GB'
-  maintenance_work_mem: '512MB'
-  checkpoint_completion_target: '0.9'
-  wal_buffers: '16MB'
-  default_statistics_target: '100'
-  random_page_cost: '1.1'
-  effective_io_concurrency: '200'
-  work_mem: '3495kB'
-  huge_pages: 'off'
-  min_wal_size: '2GB'
-  max_wal_size: '8GB'
-  max_worker_processes: '4'
-  max_parallel_workers_per_gather: '2'
-  max_parallel_workers: '4'
-  max_parallel_maintenance_workers: '2'
+    max_connections: '300'
+    shared_buffers: '2GB'
+    effective_cache_size: '6GB'
+    maintenance_work_mem: '512MB'
+    checkpoint_completion_target: '0.9'
+    wal_buffers: '16MB'
+    default_statistics_target: '100'
+    random_page_cost: '1.1'
+    effective_io_concurrency: '200'
+    work_mem: '3495kB'
+    huge_pages: 'off'
+    min_wal_size: '2GB'
+    max_wal_size: '8GB'
+    max_worker_processes: '4'
+    max_parallel_workers_per_gather: '2'
+    max_parallel_workers: '4'
+    max_parallel_maintenance_workers: '2'
 
 # Open PostgreSQL Port
 open_ports_default_comment: '{{ postgres_ha_service_name }}'


### PR DESCRIPTION
After one week of larger hardware in `status.prod`'s db hosts (8 GB RAM, 4 CPUs) we still don't have an evident performance enhancement.
This PR aims at getting the major profit from the current hardware in `status.prod`.

We still have high swap level and the RAM is not completely used:
![image](https://github.com/user-attachments/assets/6b42c215-f7af-41a7-85a6-5052dba0e0c3)
![image](https://github.com/user-attachments/assets/efe2e60d-7e21-4183-ac7f-0d6d88148f1b)

:warning: these new settings might not be suitable for current `status.staging`'s hardware.

------

:information_source: 
I attach the stats before and after increasing the hw
[stats-prev.csv](https://github.com/user-attachments/files/16522720/stats-prev.csv)
[stats.csv](https://github.com/user-attachments/files/16522721/stats.csv)

