### PR TITLE
store: Add store-sync protocol for staging store nodes

### DIFF
--- a/ansible/group_vars/store.yml
+++ b/ansible/group_vars/store.yml
@@ -14,7 +14,10 @@ nim_waku_cont_name: 'nim-waku-store'
 nim_waku_cont_vol: '/docker/{{ nim_waku_cont_name }}'
 nim_waku_node_conf_path: '{{ nim_waku_cont_vol }}/conf'
 nim_waku_log_level: 'debug'
-nim_waku_protocols_enabled: ['relay', 'store']
+nim_waku_protocols_enabled_map:
+  prod: ['relay', 'store']
+  staging: ['relay', 'store', 'store-sync']
+nim_waku_protocols_enabled: '{{ nim_waku_protocols_enabled_map[stage] }}'
 nim_waku_disc_v5_enabled: true
 nim_waku_dns4_domain_name: '{{ dns_entry }}'
 nim_waku_node_key: '{{lookup("bitwarden", "fleets/status/"+stage+"/nodekeys", field=hostname)}}'


### PR DESCRIPTION
This PR is to enable the store-sync protocol on only the status.staging store nodes.
This will allow us to validate it before deploying on the production nodes