### PR TITLE
boot: update sonda and nim waku networking

### DIFF
--- a/ansible/group_vars/boot.yml
+++ b/ansible/group_vars/boot.yml
@@ -12,6 +12,7 @@ nim_waku_cont_tag: 'deploy-{{ env }}-{{ stage }}'
 nim_waku_cont_name: 'nim-waku-boot'
 nim_waku_cont_vol: '/docker/{{ nim_waku_cont_name }}'
 nim_waku_node_conf_path: '{{ nim_waku_cont_vol }}/conf'
+nim_waku_cont_network: '{{ nim_waku_cont_name }}'
 nim_waku_log_level: 'debug'
 nim_waku_protocols_enabled: ['relay', 'filter', 'lightpush', 'peer-exchange']
 nim_waku_disc_v5_enabled: true
@@ -73,7 +74,10 @@ nim_waku_consul_failures_before_critical: 20
 # Monitoring
 nim_waku_sonda_enabled: true
 nim_waku_sonda_metrics_port: 8004
-nim_waku_node_rest_address: 'http://{{ inventory_hostname }}.wg:{{ nim_waku_rest_port }}'
+nim_waku_sonda_pubsub_topics: '{{ nim_waku_pubsub_topics }}'
+nim_waku_sonda_cluster_id: '{{ nim_waku_cluster_id }}'
+nim_waku_sonda_cont_network: '{{ nim_waku_cont_network }}'
+nim_waku_sonda_node_rest_address: 'http://{{ nim_waku_cont_name }}:{{ nim_waku_rest_port }}'
 
 # LetsEncrypt via Certbot
 certbot_docker_enabled: true
@@ -100,7 +104,6 @@ open_ports_list:
     - { comment: 'Nim-Waku LibP2P',        port: '{{ nim_waku_p2p_tcp_port }}' }
     - { comment: 'Nim-Waku Discovery v5',  port: '{{ nim_waku_disc_v5_port }}',       protocol: 'udp' }
     - { comment: 'Nim-Waku Metrics',       port: '{{ nim_waku_metrics_port }}',       ipset: 'hq.metrics', iifname: 'wg0' }
-    - { comment: 'Nim-Waku REST API port', port: '{{ nim_waku_rest_port }}',          ipset: '{{ env }}.{{ stage }}', iifname: 'wg0' }
     - { comment: 'Nim-Waku WebSocket',     port: '{{ nim_waku_websock_port }}' }
   nim-waku-sonda:
     - { comment: 'Nim-Waku Sonda Metrics', port: '{{ nim_waku_sonda_metrics_port }}', ipset: 'hq.metrics', iifname: 'wg0' }

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -30,4 +30,4 @@
 
 - name: infra-role-nim-waku-sonda
   src: git@github.com:status-im/infra-role-nim-waku-sonda.git
-  version: 1c319bc86553f1583bcddbbdca969238d9e26e3e
+  version: d0d2bb8b82804b8ca92a6d7953e5eec982feb20d


### PR DESCRIPTION
Define docker default network for nim-waku on boot nodes and use that network when deploying sonda. Remove existing nftables rule for opening nim waku rest api port since it is not needed anymore.