### PR TITLE
staging: decommission DCs other than DigitalOcean

### DIFF
--- a/hosts_boot.tf
+++ b/hosts_boot.tf
@@ -8,7 +8,9 @@ module "boot" {
   stage  = terraform.workspace
 
   /* scaling */
-  host_count = local.ws["boot_hosts_count"]
+  ac_count = local.ws["boot_ac_count"]
+  do_count = local.ws["boot_do_count"]
+  gc_count = local.ws["boot_gc_count"]
 
   /* instance sizes */
   do_type = local.ws["boot_do_type"] /* DigitalOcean */
@@ -25,4 +27,3 @@ module "boot" {
     "9000", /* discovery v5 */
   ]
 }
-

--- a/hosts_store.tf
+++ b/hosts_store.tf
@@ -8,7 +8,9 @@ module "store" {
   stage  = terraform.workspace
 
   /* scaling */
-  host_count = local.ws["store_hosts_count"]
+  ac_count = local.ws["store_ac_count"]
+  do_count = local.ws["store_do_count"]
+  gc_count = local.ws["store_gc_count"]
 
   /* instance sizes */
   do_type = local.ws["store_do_type"] /* DigitalOcean */
@@ -25,4 +27,3 @@ module "store" {
     "9000", /* discovery v5 */
   ]
 }
-

--- a/hosts_store_db.tf
+++ b/hosts_store_db.tf
@@ -8,16 +8,17 @@ module "store-db" {
   stage  = terraform.workspace
 
   /* scaling */
-  host_count = local.ws["store_db_hosts_count"]
+  ac_count = local.ws["store_db_ac_count"]
+  do_count = local.ws["store_db_do_count"]
+  gc_count = local.ws["store_db_gc_count"]
 
   /* instance sizes */
-  do_type = local.ws["db_do_type"] /* DigitalOcean */
-  ac_type = local.ws["db_ac_type"] /* Alibaba Cloud */
-  gc_type = local.ws["db_gc_type"] /* Google Cloud */
+  do_type = local.ws["store_db_do_type"] /* DigitalOcean */
+  ac_type = local.ws["store_db_ac_type"] /* Alibaba Cloud */
+  gc_type = local.ws["store_db_gc_type"] /* Google Cloud */
 
   /* data volumes */
   ac_data_vol_size = local.ws["store_db_data_vol_size"]
   do_data_vol_size = local.ws["store_db_data_vol_size"]
   gc_data_vol_size = local.ws["store_db_data_vol_size"]
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "hosts" {
+  value = merge(
+    module.boot.hosts,
+    module.store.hosts,
+    module.store-db.hosts
+  )
+}

--- a/workspaces.tf
+++ b/workspaces.tf
@@ -11,9 +11,18 @@ locals {
     defaults = {
       /* Default settings for all fleets/workspaces. */
 
-      boot_hosts_count = 1
-      store_hosts_count = 2
-      store_db_hosts_count = 1
+      boot_ac_count = 1
+      boot_do_count = 1
+      boot_gc_count = 1
+
+      store_ac_count = 2
+      store_do_count = 2
+      store_gc_count = 2
+
+      store_db_ac_count = 1
+      store_db_do_count = 1
+      store_db_gc_count = 1
+
       store_db_data_vol_size = 100
 
       store_do_type = "s-1vcpu-2gb"        /* DigitalOcean */
@@ -24,39 +33,44 @@ locals {
       boot_ac_type = "ecs.t5-lc1m2.small" /* Alibaba Cloud */
       boot_gc_type = "g1-small"           /* Google Cloud */
 
-      db_do_type = "s-1vcpu-2gb"          /* DigitalOcean */
-      db_ac_type = "ecs.t5-lc1m2.small"   /* Alibaba Cloud */
-      db_gc_type = "g1-small"             /* Google Cloud */
+      store_db_do_type = "s-1vcpu-2gb"          /* DigitalOcean */
+      store_db_ac_type = "ecs.t5-lc1m2.small"   /* Alibaba Cloud */
+      store_db_gc_type = "g1-small"             /* Google Cloud */
     }
 
     /* Settings specific to the test fleet/workspace. */
     prod = {
-      store_do_type = "s-4vcpu-8gb"
-      store_ac_type = "ecs.t5-lc1m4.large"
-      store_gc_type = "c2d-standard-4"
-
       boot_do_type = "s-2vcpu-4gb"
       boot_ac_type = "ecs.t5-lc1m2.large"
       boot_gc_type = "c2d-standard-2"
 
-      db_do_type = "c2-16vcpu-32gb-intel"
-      db_ac_type = "ecs.c6.4xlarge"
-      db_gc_type = "c2d-highcpu-16"
+      store_do_type = "s-4vcpu-8gb"
+      store_ac_type = "ecs.t5-lc1m4.large"
+      store_gc_type = "c2d-standard-4"
+
+      store_db_do_type = "c2-16vcpu-32gb-intel"
+      store_db_ac_type = "ecs.c6.4xlarge"
+      store_db_gc_type = "c2d-highcpu-16"
 
       store_db_data_vol_size = 320
     }
+    /* DO data center only to limit costs. */
     staging = {
+      boot_ac_count = 0
+      boot_do_count = 1
+      boot_gc_count = 0
+
+      store_ac_count = 0
+      store_do_count = 2
+      store_gc_count = 0
+
+      store_db_ac_count = 0
+      store_db_do_count = 1
+      store_db_gc_count = 0
+
       store_do_type = "s-2vcpu-4gb"
-      store_ac_type = "ecs.t5-lc1m2.large"
-      store_gc_type = "c2d-highcpu-2"
-
       boot_do_type = "s-2vcpu-4gb"
-      boot_ac_type = "ecs.t5-lc1m2.large"
-      boot_gc_type = "c2d-highcpu-2"
-
-      db_do_type = "s-2vcpu-4gb"
-      db_ac_type = "ecs.t5-lc1m2.large"
-      db_gc_type = "c2d-highcpu-2"
+      store_db_do_type = "s-2vcpu-4gb"
     }
   }
 }


### PR DESCRIPTION
We do not currently need that many hosts based on discussion with Status dev team and Logos Delivery team. Status E2E tests should use local nodes.